### PR TITLE
Ensure text input is focused after file is attached

### DIFF
--- a/src/components/AttachFileButton.tsx
+++ b/src/components/AttachFileButton.tsx
@@ -10,7 +10,7 @@ import { notifications } from "../notifications";
 import { roundFileSizeInMB } from "../utils/roundFileSizeInMB";
 import { hiddenInputStyles } from "./styles/AttachFileButton.styles";
 
-export const AttachFileButton = () => {
+export const AttachFileButton = ({ textAreaRef }: { textAreaRef?: React.RefObject<HTMLTextAreaElement> }) => {
     const fileInputRef: React.RefObject<HTMLInputElement> = useRef(null);
     const { attachedFiles, fileAttachmentConfig } = useSelector((state: AppState) => ({
         attachedFiles: state.chat.attachedFiles || [],
@@ -70,6 +70,7 @@ export const AttachFileButton = () => {
         if (fileInputRef.current) {
             fileInputRef.current.value = "";
         }
+        textAreaRef?.current?.focus();
     };
 
     return (

--- a/src/components/MessageInput.tsx
+++ b/src/components/MessageInput.tsx
@@ -120,7 +120,9 @@ export const MessageInput = () => {
                             maxLength={CHAR_LIMIT}
                         />
                     </Box>
-                    <Box {...messageOptionContainerStyles}>{fileAttachmentConfig?.enabled && <AttachFileButton />}</Box>
+                    <Box {...messageOptionContainerStyles}>
+                        {fileAttachmentConfig?.enabled && <AttachFileButton textAreaRef={textAreaRef} />}
+                    </Box>
                     <Box {...messageOptionContainerStyles}>
                         <Button
                             data-test="message-send-button"

--- a/src/components/__tests__/AttachFileButton.test.tsx
+++ b/src/components/__tests__/AttachFileButton.test.tsx
@@ -1,5 +1,6 @@
-import { fireEvent, render, waitFor } from "@testing-library/react";
+import { fireEvent, prettyDOM, render, waitFor } from "@testing-library/react";
 import "@testing-library/jest-dom";
+import React from "react";
 
 import * as genericActions from "../../store/actions/genericActions";
 import { notifications } from "../../notifications";
@@ -78,6 +79,26 @@ describe("Attach File Button", () => {
         );
 
         expect(fileInput).toHaveValue("");
+    });
+
+    it("focuses the text area on file select", async () => {
+        const textAreaRef = {
+            current: document.createElement("textarea")
+        };
+
+        const { container } = render(
+            <>
+                <AttachFileButton textAreaRef={textAreaRef} />
+                <textarea ref={textAreaRef} />
+            </>
+        );
+        const fileInput = container.querySelector(fileInputSelector) as Element;
+
+        fireEvent.change(fileInput, {
+            target: { files: [dumbFile] }
+        });
+
+        expect(textAreaRef.current).toHaveFocus();
     });
 
     it("does not attach a file that is already attached", async () => {


### PR DESCRIPTION
<!-- Describe your Pull Request -->

Previously the attach file button would remain focused after a file is attached. Now the text input (textarea element) is focused.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [ ] I acknowledge that all my contributions will be made under the project's license.
