### PR TITLE
Add clean up step to e2e pipelines

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,6 +13,20 @@ executors:
       - image: 'cypress/browsers:node14.17.0-chrome91-ff89'
 
 jobs:
+  cleanUp:
+    docker:
+      - image: cimg/node:14.18.1
+    steps:
+      - checkout
+      - run:
+          command: npm install twilio --no-save
+          name: Install Twilio client
+      - run:
+          command: |
+            yarn e2eCleanupExistingTasks \
+                accountSid=$TWILIO_ACCOUNT_SID \
+                authToken=$TWILIO_AUTH_TOKEN \
+          name: Cleanup existing tasks
   runUnitTests:
     docker:
       - image: cimg/node:14.18.1
@@ -74,8 +88,13 @@ jobs:
 workflows:
   build:
     jobs:
-      - runUnitTests
+      - cleanUp
+      - runUnitTests:
+          requires:
+            - cleanUp
       - cypress/run:
+          requires:
+            - cleanUp
           executor: with-chrome
           post-install:
             - run: "yarn bootstrap \
@@ -90,4 +109,6 @@ workflows:
           yarn: true
           start: 'yarn start & yarn server:ci' # start server before running tests
           store_artifacts: true
-      - cypressTestsOnSauce
+      - cypressTestsOnSauce:
+          requires:
+            - cleanUp

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "test": "react-app-rewired test --env=jsdom --transformIgnorePatterns \"node_modules/(?!(@twilio-paste|@twilio/conversations))/\"",
     "test:nowatch": "yarn test --watchAll=false --verbose --runInBand",
     "bootstrap": "node scripts/bootstrap",
+    "e2eCleanupExistingTasks": "node scripts/e2eCleanupExistingTasks",
     "deploy": "yarn build && node scripts/deploy",
     "eject": "react-app-rewired eject"
   },

--- a/scripts/e2eCleanupExistingTasks.js
+++ b/scripts/e2eCleanupExistingTasks.js
@@ -1,0 +1,44 @@
+const params = process.argv.slice(2);
+const Twilio = require("twilio");
+
+const getParams = () => {
+    const { accountSid, authToken } = params.reduce((acc, arg) => {
+        const [, key, val] = arg.match(/(\w*)=(\S*)/) || [];
+
+        if (key) {
+            acc[key] = val;
+        }
+
+        return acc;
+    }, {});
+
+    return { accountSid, authToken };
+};
+
+const cleanupTasks = async () => {
+    const { accountSid, authToken } = getParams();
+    console.log("getting client");
+    const client = new Twilio(accountSid, authToken);
+
+    console.log("getting workspace");
+    const [{ sid: workspaceSid }] = await client.taskrouter.workspaces.list();
+
+    console.log("getting tasks");
+    const tasks = await client.taskrouter.workspaces(workspaceSid).tasks.list();
+
+    console.log("proceeding to remove older tasks");
+    await Promise.all(
+        tasks.map((t) => {
+            // Only delete tasks older than 10 minutes to avoid breaking other pipelines
+            if (t.dateCreated.getTime() < Date.now() - 60 * 10 * 1000) {
+                console.log("deleting task", t.sid);
+                return t.remove();
+            }
+            return Promise.resolve();
+        })
+    );
+
+    console.log("done");
+};
+
+cleanupTasks();


### PR DESCRIPTION
To avoid pipelines failures due to agents having too many pending leftover tasks, we are adding a step to clean them up before running e2e tests.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
