### PR TITLE
FLEXEXP-561 Ignore focus events triggered by mouse events on message bubbles

### DIFF
--- a/.sauce/config.yml
+++ b/.sauce/config.yml
@@ -41,7 +41,7 @@ suites:
 - name: cypress - windows 10 - firefox 100
   browser: firefox
   extendedDebugging: true
-  browserVersion: latest-1
+  browserVersion: 100
   platformName: windows 10
   config:
     testFiles:

--- a/.sauce/config.yml
+++ b/.sauce/config.yml
@@ -38,7 +38,7 @@ suites:
 #  config:
 #    testFiles:
 #    - '**/*.*'
-- name: cypress - windows 10 - firefox latest-1
+- name: cypress - windows 10 - firefox 100
   browser: firefox
   extendedDebugging: true
   browserVersion: latest-1

--- a/src/components/MessageBubble.tsx
+++ b/src/components/MessageBubble.tsx
@@ -38,6 +38,7 @@ export const MessageBubble = ({
     updateFocus: (newFocus: number) => void;
 }) => {
     const [read, setRead] = useState(false);
+    const [isMouseDown, setIsMouseDown] = useState(false);
     const { conversationsClient, participants, users, fileAttachmentConfig } = useSelector((state: AppState) => ({
         conversationsClient: state.chat.conversationsClient,
         participants: state.chat.participants,
@@ -92,9 +93,20 @@ export const MessageBubble = ({
         }
     };
 
+    const handleMouseDown = () => {
+        setIsMouseDown(true);
+    };
+
+    const handleMouseUp = () => {
+        setIsMouseDown(false);
+    };
+
     const handleFocus = () => {
-        // Necessary since screen readers can set the focus to any focusable element
-        updateFocus(message.index);
+        // Ignore focus from clicks
+        if (!isMouseDown) {
+            // Necessary since screen readers can set the focus to any focusable element
+            updateFocus(message.index);
+        }
     };
 
     const author = users?.find((u) => u.identity === message.author)?.friendlyName || message.author;
@@ -105,6 +117,8 @@ export const MessageBubble = ({
             tabIndex={focusable ? 0 : -1}
             onFocus={handleFocus}
             onKeyDown={handleKeyDown}
+            onMouseDown={handleMouseDown}
+            onMouseUp={handleMouseUp}
             ref={messageRef}
             data-message-bubble
             data-testid="message-bubble"

--- a/src/components/__tests__/MessageList.test.tsx
+++ b/src/components/__tests__/MessageList.test.tsx
@@ -530,5 +530,34 @@ describe("Message List", () => {
             expect(bottomBubble.tabIndex).toBe(0);
             expect(bottomBubble).toHaveFocus();
         });
+
+        it("does not focus if triggered by a click", async () => {
+            const message3 = { ...message2, index: 2 };
+            const messages = [message1, message2, message3];
+            (useSelector as jest.Mock).mockImplementation((callback: any) =>
+                callback({
+                    ...defaultState,
+                    chat: {
+                        ...defaultState.chat,
+                        messages
+                    }
+                })
+            );
+            const { queryAllByTestId } = render(<MessageList />);
+
+            const [topBubble, middleBubble, bottomBubble] = queryAllByTestId(messageBubbleTestId);
+
+            fireEvent.keyDown(bottomBubble, {
+                key: "ArrowUp"
+            });
+
+            expect(middleBubble.tabIndex).toBe(0);
+            expect(middleBubble).toHaveFocus();
+
+            topBubble.click();
+
+            expect(middleBubble.tabIndex).toBe(0);
+            expect(middleBubble).toHaveFocus();
+        });
     });
 });


### PR DESCRIPTION
This fixes a bug where clicking any message bubble after a new message has come in would focus that most recent message and scroll to it (even if you were scrolled up much higher in the chat history).

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
