### PR TITLE
Fix import of ScreenReaderOnly so it is not importing all of core

### DIFF
--- a/src/components/MessageBubble.tsx
+++ b/src/components/MessageBubble.tsx
@@ -1,6 +1,6 @@
 import { Media, Message } from "@twilio/conversations";
 import { Box } from "@twilio-paste/core/box";
-import { ScreenReaderOnly } from "@twilio-paste/core";
+import { ScreenReaderOnly } from "@twilio-paste/core/screen-reader-only";
 import { useSelector } from "react-redux";
 import { Text } from "@twilio-paste/core/text";
 import { Flex } from "@twilio-paste/core/flex";


### PR DESCRIPTION
As per [this Paste guideline](https://paste.twilio.design/core/#import-differences) imports of components should be made from their respective directories and not `@twilio-paste/core` directly. We weren't following this guideline in one place, this PR fixes that.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
