### PR TITLE
Remove EntryPoint padding added by Mobile Safari

### DIFF
--- a/src/components/styles/EntryPoint.styles.ts
+++ b/src/components/styles/EntryPoint.styles.ts
@@ -14,6 +14,7 @@ export const containerStyles: BoxStyleProps = {
     cursor: "pointer",
     transition: "background-color 0.2s",
     outline: "0px",
+    padding: "space0",
     _hover: {
         backgroundColor: "colorBackgroundPrimaryStronger"
     },


### PR DESCRIPTION
Mobile Safari adds some padding to inputs that was not accounted for, which results in the icon in the EntryPoint button erroneously being incredibly tiny on iOS. This fixes that to provide a consistent appearance across browsers.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
