### PR TITLE
Add missing step to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,6 +272,12 @@ Once the bundle is uploaded, make sure to have it loaded in your website page, a
 <script src="https://[...]webchat.js"></script>
 ```
 
+Next, declare the root element that the webchat widget will be rendered into:
+
+```html
+<div id="twilio-webchat-widget-root"></div>
+```
+
 Finally, add the code to initialize the webchat widget as per following example. It is crucial that you update the `serverUrl` with the base URL of your endpoints.
 The React App will then target `/initWebchat` and `/refreshToken` endpoints. If you want to use different endpoint urls, make sure to upload the code in `src/sessionDataHandler.ts`.
 


### PR DESCRIPTION
The readme currently does not indicate that the root div for webchat needs a specific id; this adds a step for it.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
