### PR TITLE
fixing typo `target_branch` -> `target-branch`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,4 +9,4 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
-    target_branch: "flex-webchat-ui"
+    target-branch: "flex-webchat-ui"


### PR DESCRIPTION
Fixing Typo

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
