### PR TITLE
FLEXIN-434 - Reading theme preferences from search params

### DIFF
--- a/public/app.css
+++ b/public/app.css
@@ -1,24 +1,47 @@
-html, body {
+html {
+  font-size: 16px;
   height: 100%;
 }
 html > body {
+  height: 100%;
   margin: 0;
   position: relative;
   background-size: cover;
-  background-image: url(https://media.twiliocdn.com/sdk/js/webchat-v3/assets/webchat-background.png);
-  background-color: #6d7697;
 }
-body:after {
+[data-theme-pref] {
+  background-size: cover;
+  height: 100%;
+  width: 100%;
+  background-repeat: no-repeat;
+  background-size: cover; 
+  background-color: transparent;
+}
+[data-theme-pref]::after {
   content: "";
   position: absolute;
-  top: 50%;
-  left: 50%;
-  width: 174px;
-  height: 182px;
-  margin-left: -87px;
-  margin-top: -91px;
-  opacity: .2;
-  background: url(https://media.twiliocdn.com/sdk/js/webchat-v3/assets/webchat-logo.svg);
+  left: 1.25rem;
+  bottom: 1rem;
+  width: 8rem;
+  height: 3rem;
+  margin-left: 0rem;
+  margin-top: 0rem;  
+  background-repeat: no-repeat;
+  background-size: cover; 
+  background-color: transparent;
+}
+[data-theme-pref="light-theme"] {
+  background-image: url("https://media.twiliocdn.com/sdk/js/webchat-v3/assets/twilio-webchat-bg-light.jpg");
+}
+[data-theme-pref="light-theme"]::after {
+  background-color: transparent;
+  background-image: url("https://media.twiliocdn.com/sdk/js/webchat-v3/assets/twilio-flex-logo-transparent-light.png");
+}
+[data-theme-pref="dark-theme"] {
+  background-image: url("https://media.twiliocdn.com/sdk/js/webchat-v3/assets/twilio-webchat-bg-dark.jpg");
+}
+[data-theme-pref="dark-theme"]::after {
+  background-color: transparent;
+  background-image: url("https://media.twiliocdn.com/sdk/js/webchat-v3/assets/twilio-flex-logo-transparent-dark.png");
 }
 
 @font-face {

--- a/public/app.js
+++ b/public/app.js
@@ -1,7 +1,7 @@
 window.addEventListener("DOMContentLoaded", () => {
   const urlParams = new URLSearchParams(window.location.search);
   const isLightTheme = urlParams.get("theme") === "light";
-  const el = document.querySelector("[data-theme-pref='light-theme']");
+  const el = document.querySelector("[data-theme-pref]");
 
   el && el.setAttribute("data-theme-pref", isLightTheme ? "light-theme" : "dark-theme");
 

--- a/public/app.js
+++ b/public/app.js
@@ -1,12 +1,16 @@
 window.addEventListener("DOMContentLoaded", () => {
   const urlParams = new URLSearchParams(window.location.search);
+  const isLightTheme = urlParams.get("theme") === "light";
+  const el = document.querySelector("[data-theme-pref='light-theme']");
+
+  el && el.setAttribute("data-theme-pref", isLightTheme ? "light-theme" : "dark-theme");
+
   Twilio.initLogger("info");
   Twilio.initWebchat({
     deploymentKey: urlParams.get("deploymentKey"),
     region: urlParams.get("region"),
     theme: {
-      isLight: true
+      isLight: isLightTheme
     }
   })
 });
-

--- a/public/demo.html
+++ b/public/demo.html
@@ -8,7 +8,7 @@
   <title>Twilio Webchat React App</title>
   <link rel="stylesheet" type="text/css" href="https://media.twiliocdn.com/sdk/js/webchat-v3/assets/app.css"></link>
 </head>
-<body>
+<body data-theme-pref="light-theme">
 <noscript>
   You need to enable JavaScript to run this app.
 </noscript>

--- a/public/index.html
+++ b/public/index.html
@@ -23,25 +23,12 @@
   <link rel="stylesheet" href="./app.css">
 </head>
 
-<body>
+<body data-theme-pref="light-theme">
   <noscript>
     You need to enable JavaScript to run this app.
   </noscript>
   <div id="twilio-webchat-widget-root"></div>
-  <script>
-    window.addEventListener("DOMContentLoaded", () => {
-      const urlParams = new URLSearchParams(window.location.search);
-      Twilio.initLogger("info");
-      Twilio.initWebchat({
-        serverUrl: "%REACT_APP_SERVER_URL%",
-        deploymentKey: urlParams.get("deploymentKey") || "%REACT_APP_DEPLOYMENT_KEY%",
-        region: urlParams.get("region") || "%REACT_APP_REGION%",
-        theme: {
-          isLight: true
-        }
-      })
-    })
-  </script>
+  <script src="./app.js"> </script>
 </body>
 
 </html>

--- a/public/index.html
+++ b/public/index.html
@@ -28,7 +28,25 @@
     You need to enable JavaScript to run this app.
   </noscript>
   <div id="twilio-webchat-widget-root"></div>
-  <script src="./app.js"> </script>
+  <script>
+    window.addEventListener("DOMContentLoaded", () => {
+      const urlParams = new URLSearchParams(window.location.search);
+      const isLightTheme = urlParams.get("theme") === "light";
+      const el = document.querySelector("[data-theme-pref='light-theme']");
+
+      el && el.setAttribute("data-theme-pref", isLightTheme ? "light-theme" : "dark-theme");
+
+      Twilio.initLogger("info");
+      Twilio.initWebchat({
+        serverUrl: "%REACT_APP_SERVER_URL%",
+        deploymentKey: urlParams.get("deploymentKey"),
+        region: urlParams.get("region") || "%REACT_APP_REGION%",
+        theme: {
+          isLight: isLightTheme
+        }
+      })
+    });
+  </script>
 </body>
 
 </html>

--- a/public/index.html
+++ b/public/index.html
@@ -32,7 +32,7 @@
     window.addEventListener("DOMContentLoaded", () => {
       const urlParams = new URLSearchParams(window.location.search);
       const isLightTheme = urlParams.get("theme") === "light";
-      const el = document.querySelector("[data-theme-pref='light-theme']");
+      const el = document.querySelector("[data-theme-pref]");
 
       el && el.setAttribute("data-theme-pref", isLightTheme ? "light-theme" : "dark-theme");
 


### PR DESCRIPTION
<!-- Describe your Pull Request -->

**Contributing to Twilio**
Now url supports theme as search params. provide theme="light||dark" to set the theming out of the box.

<img width="1443" alt="Screenshot 2023-10-09 at 6 28 21 PM" src="https://github.com/twilio/twilio-webchat-react-app/assets/18657542/f31e1fb4-20b3-4ea7-a3ae-396307b28e49">
<img width="1443" alt="Screenshot 2023-10-09 at 6 28 08 PM" src="https://github.com/twilio/twilio-webchat-react-app/assets/18657542/5feba549-25a0-4091-a315-bb07f0348b57">
![Uploading Screenshot 2023-10-10 at 12.43.52 PM.png…]()


> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
