### PR TITLE
[FLEXIN-470] - header now starts with x-twilio prefix

### DIFF
--- a/src/utils/generateSecurityHeaders.test.ts
+++ b/src/utils/generateSecurityHeaders.test.ts
@@ -8,10 +8,10 @@ import WebChatLogger from "../logger";
 
 jest.mock("../logger");
 
-const HEADER_SEC_DECODER = "i-twilio-sec-decoders";
-const HEADER_SEC_USERAGENT = "i-twilio-user-agent";
-const HEADER_SEC_USERSETTINGS = "i-twilio-sec-usersettings";
-const HEADER_SEC_WEBCHAT = "i-twilio-sec-webchatinfo";
+const HEADER_SEC_DECODER = "x-twilio-sec-decoders";
+const HEADER_SEC_USERAGENT = "x-twilio-user-agent";
+const HEADER_SEC_USERSETTINGS = "x-twilio-sec-usersettings";
+const HEADER_SEC_WEBCHAT = "x-twilio-sec-webchatinfo";
 
 describe("Generate Security Headers", () => {
     beforeAll(() => {

--- a/src/utils/generateSecurityHeaders.ts
+++ b/src/utils/generateSecurityHeaders.ts
@@ -1,10 +1,10 @@
 import { LOCALSTORAGE_SESSION_ITEM_ID } from "../sessionDataHandler";
 import { store } from "../store/store";
 
-const HEADER_SEC_DECODER = "i-twilio-sec-decoders";
-const HEADER_SEC_USER_AGENT = "i-twilio-user-agent";
-const HEADER_SEC_USERSETTINGS = "i-twilio-sec-usersettings";
-const HEADER_SEC_WEBCHAT = "i-twilio-sec-webchatinfo";
+const HEADER_SEC_DECODER = "x-twilio-sec-decoders";
+const HEADER_SEC_USER_AGENT = "x-twilio-user-agent";
+const HEADER_SEC_USERSETTINGS = "x-twilio-sec-usersettings";
+const HEADER_SEC_WEBCHAT = "x-twilio-sec-webchatinfo";
 
 type SecurityHeadersType = {
     [HEADER_SEC_USER_AGENT]: string;


### PR DESCRIPTION
<!-- Describe your Pull Request -->

Headers now starts with `X-Twilio` prefix. 

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
