### PR TITLE
[FLEXIN-535] - Fix region sets to null

### DIFF
--- a/shared/regionUtil.js
+++ b/shared/regionUtil.js
@@ -3,11 +3,13 @@ function parseRegionForHTTP(region) {
         case "prod":
         case "us1":
         case "":
+        case undefined:
+        case null:
             return "";
         case "dev-us1":
-            return ".dev";
+          return ".dev";
         case "stage-us1":
-            return ".stage";
+          return ".stage";
         default:
             return `.${region}`;
     }
@@ -34,6 +36,8 @@ function parseRegionForTwilioClient(region) {
     switch (region) {
         case "prod":
         case "us1":
+        case undefined:
+        case null:
             return "";
         case "stage-us1":
             return "stage";
@@ -48,6 +52,8 @@ function parseRegionForConversations(region) {
     switch (region) {
         case "prod":
         case "":
+        case undefined:
+        case null:
             return "us1";
         case "dev":
             return "dev-us1";

--- a/src/utils/regionUtil.test.ts
+++ b/src/utils/regionUtil.test.ts
@@ -17,6 +17,14 @@ describe("Build Regions", () => {
                 regionExpected: ""
             },
             {
+                regionPassed: null,
+                regionExpected: ""
+            },
+            {
+                regionPassed: undefined,
+                regionExpected: ""
+            },
+            {
                 regionPassed: "prod",
                 regionExpected: ""
             },
@@ -53,6 +61,14 @@ describe("Build Regions", () => {
             },
             {
                 regionPassed: "",
+                regionParsed: "us1"
+            },
+            {
+                regionPassed: null,
+                regionParsed: "us1"
+            },
+            {
+                regionPassed: undefined,
                 regionParsed: "us1"
             },
             {

--- a/src/utils/regionUtil.ts
+++ b/src/utils/regionUtil.ts
@@ -1,8 +1,10 @@
-export function buildRegionalHost(region: string | undefined = ""): string {
+export function buildRegionalHost(region?: string | null): string {
     switch (region) {
         case "prod":
         case "us1":
         case "":
+        case undefined:
+        case null:
             return "";
         case "dev-us1":
             return ".dev";
@@ -13,10 +15,12 @@ export function buildRegionalHost(region: string | undefined = ""): string {
     }
 }
 
-export function parseRegionForConversations(region: string | undefined = ""): string {
+export function parseRegionForConversations(region?: string | null): string {
     switch (region) {
         case "prod":
         case "":
+        case undefined:
+        case null:
             return "us1";
         case "dev":
             return "dev-us1";


### PR DESCRIPTION
<!-- Describe your Pull Request -->
In case of null or undefined, region should be set to prod-us1

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
