### PR TITLE
[FLEXIN-638] - Refresh API Now works as expected

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -46,6 +46,11 @@
       "rules": {
         "camelcase": ["off"]
       }
+    }, {
+      "files": ["src/sessionDataHandler.ts"],
+      "rules": {
+        "camelcase": ["off"]
+      }
     }
   ]
 }

--- a/src/__tests__/sessionDataHandler.test.ts
+++ b/src/__tests__/sessionDataHandler.test.ts
@@ -80,7 +80,7 @@ describe("session data handler", () => {
 
             jest.useFakeTimers().setSystemTime(new Date("2023-01-01"));
 
-            const currentTime = Date.now();
+            const currentTime = Date.now().toString();
             const tokenPayload = {
                 expiration: `${currentTime + 10e5}`,
                 token: "new token",
@@ -95,7 +95,15 @@ describe("session data handler", () => {
                 ...sessionDataHandler.processNewTokenResponse(tokenPayload),
                 loginTimestamp: currentTime
             };
-            expect(setLocalStorageItemSpy).toHaveBeenCalledWith("TWILIO_WEBCHAT_WIDGET", JSON.stringify(expected));
+            expect(setLocalStorageItemSpy).toHaveBeenCalledTimes(2);
+            expect(setLocalStorageItemSpy).toHaveBeenNthCalledWith(1, "TWILIO_WEBCHAT_WIDGET", JSON.stringify({
+                token: "",
+                expiration: "",
+                identity: "",
+                conversationSid: "",
+                loginTimestamp: currentTime
+            }));
+            expect(setLocalStorageItemSpy).toHaveBeenNthCalledWith(2, "TWILIO_WEBCHAT_WIDGET", JSON.stringify(expected));
         });
 
         it("should return a new token", async () => {

--- a/src/components/WebchatWidget.tsx
+++ b/src/components/WebchatWidget.tsx
@@ -17,7 +17,7 @@ export function WebchatWidget() {
     useEffect(() => {
         const data = sessionDataHandler.tryResumeExistingSession();
         const logger = window.Twilio.getLogger("WebChatWidget");
-        if (data) {
+        if (data && data.token && data.conversationSid) {
             try {
                 logger.info("Initializing session.");
                 dispatch(initSession({ token: data.token, conversationSid: data.conversationSid }));

--- a/src/sessionDataHandler.ts
+++ b/src/sessionDataHandler.ts
@@ -6,7 +6,7 @@ export const LOCALSTORAGE_SESSION_ITEM_ID = "TWILIO_WEBCHAT_WIDGET";
 const CUSTOMER_DEFAULT_NAME = "Customer";
 
 type SessionDataStorage = ProcessedTokenResponse & {
-    loginTimestamp: number | null;
+    loginTimestamp: string | null;
 };
 
 type InitWebchatAPIPayload = {
@@ -17,7 +17,7 @@ type InitWebchatAPIPayload = {
 
 type RefreshTokenAPIPayload = {
     DeploymentKey: string;
-    token: string;
+    Token: string;
 };
 
 export async function contactBackend<T>(
@@ -132,7 +132,7 @@ class SessionDataHandler {
         try {
             newTokenData = await contactBackend<TokenResponse>("/Webchat/Tokens/Refresh", {
                 DeploymentKey: this._deploymentKey,
-                token: storedTokenData.token
+                Token: storedTokenData.token
             });
         } catch (e) {
             logger.error(`Something went wrong when trying to get an updated token: ${e}`);
@@ -152,9 +152,18 @@ class SessionDataHandler {
     async fetchAndStoreNewSession({ formData }: { formData: Record<string, unknown> }) {
         const logger = window.Twilio.getLogger("SessionDataHandler");
         logger.info("trying to create new session");
-        const loginTimestamp = Date.now();
+        const loginTimestamp = Date.now().toString();
 
         let newTokenData;
+        storeSessionData({
+            ...this.processNewTokenResponse({
+                token: "",
+                expiration: "",
+                identity: "",
+                conversation_sid: ""
+            }),
+            loginTimestamp
+        });
 
         try {
             newTokenData = await contactBackend<TokenResponse>("/Webchat/Init", {

--- a/src/utils/generateSecurityHeaders.test.ts
+++ b/src/utils/generateSecurityHeaders.test.ts
@@ -70,8 +70,7 @@ describe("Generate Security Headers", () => {
             video: { decodingInfo: true }
         });
         expect(JSON.parse(headers[HEADER_SEC_WEBCHAT])).toMatchObject({
-            loginTimestamp: "TODAY",
-            deploymentKey: null
+            loginTimestamp: "TODAY"
         });
     });
 
@@ -124,8 +123,7 @@ describe("Generate Security Headers", () => {
             video: sampleDefaultCodecInfo
         });
         expect(JSON.parse(headers[HEADER_SEC_WEBCHAT])).toMatchObject({
-            loginTimestamp: DEFAULT_LOGIN_TIMESTAMP,
-            deploymentKey: null
+            loginTimestamp: DEFAULT_LOGIN_TIMESTAMP
         });
 
         Object.defineProperty(navigator, "mediaCapabilities", {

--- a/src/utils/generateSecurityHeaders.test.ts
+++ b/src/utils/generateSecurityHeaders.test.ts
@@ -9,7 +9,6 @@ import WebChatLogger from "../logger";
 jest.mock("../logger");
 
 const HEADER_SEC_DECODER = "x-twilio-sec-decoders";
-const HEADER_SEC_USERAGENT = "i-twilio-user-agent";
 const HEADER_SEC_USERSETTINGS = "x-twilio-sec-usersettings";
 const HEADER_SEC_WEBCHAT = "x-twilio-sec-webchatinfo";
 
@@ -59,7 +58,6 @@ describe("Generate Security Headers", () => {
         const headers = await generateSecurityHeaders();
 
         expect(headers).not.toBeFalsy();
-        expect(headers[HEADER_SEC_USERAGENT]).toEqual("USER_AGENT");
         expect(JSON.parse(headers[HEADER_SEC_USERSETTINGS])).toMatchObject({
             language: "en_US",
             cookieEnabled: true,
@@ -112,7 +110,6 @@ describe("Generate Security Headers", () => {
         let headers = await generateSecurityHeaders();
 
         expect(headers).not.toBeFalsy();
-        expect(headers[HEADER_SEC_USERAGENT]).toEqual("USER_AGENT_2");
         expect(JSON.parse(headers[HEADER_SEC_USERSETTINGS])).toMatchObject({
             language: DEFAULT_NAVIGATOR_LANG,
             cookieEnabled: DEFAULT_COOKIE_ENABLED,

--- a/src/utils/generateSecurityHeaders.ts
+++ b/src/utils/generateSecurityHeaders.ts
@@ -1,12 +1,10 @@
 import { LOCALSTORAGE_SESSION_ITEM_ID } from "../sessionDataHandler";
 
 const HEADER_SEC_DECODER = "x-twilio-sec-decoders";
-const HEADER_SEC_USER_AGENT = "i-twilio-user-agent";
 const HEADER_SEC_USERSETTINGS = "x-twilio-sec-usersettings";
 const HEADER_SEC_WEBCHAT = "x-twilio-sec-webchatinfo";
 
 type SecurityHeadersType = {
-    [HEADER_SEC_USER_AGENT]: string;
     [HEADER_SEC_USERSETTINGS]: string;
     [HEADER_SEC_WEBCHAT]: string;
     [HEADER_SEC_DECODER]: string;
@@ -98,7 +96,6 @@ export const generateSecurityHeaders = async (): Promise<SecurityHeadersType> =>
         headers[HEADER_SEC_WEBCHAT] = JSON.stringify(getWebchatInfo());
         headers[HEADER_SEC_USERSETTINGS] = JSON.stringify(getUserSpecificSettings());
         headers[HEADER_SEC_DECODER] = JSON.stringify(decoders);
-        headers[HEADER_SEC_USER_AGENT] = navigator.userAgent;
 
         return headers;
     });

--- a/src/utils/generateSecurityHeaders.ts
+++ b/src/utils/generateSecurityHeaders.ts
@@ -1,5 +1,4 @@
 import { LOCALSTORAGE_SESSION_ITEM_ID } from "../sessionDataHandler";
-import { store } from "../store/store";
 
 const HEADER_SEC_DECODER = "x-twilio-sec-decoders";
 const HEADER_SEC_USER_AGENT = "i-twilio-user-agent";
@@ -35,7 +34,6 @@ const getUserSpecificSettings = () => {
 
 const getWebchatInfo = () => {
     const sessionStorage: string = localStorage.getItem(LOCALSTORAGE_SESSION_ITEM_ID) ?? "";
-    const reduxState = store.getState();
     const logger = window.Twilio.getLogger("getWebchatInfo");
 
     let parsedStorage = null;
@@ -48,7 +46,6 @@ const getWebchatInfo = () => {
 
     return {
         loginTimestamp: parsedStorage?.loginTimestamp || DEFAULT_LOGIN_TIMESTAMP,
-        deploymentKey: reduxState?.config?.deploymentKey || null
     };
 };
 


### PR DESCRIPTION
<!-- Describe your Pull Request -->

<img width="3159" alt="Screenshot 2023-11-27 at 9 51 06 PM" src="https://github.com/twilio/twilio-webchat-react-app/assets/18657542/9d03f0ed-9f8d-41b5-b22a-6fdda4b48ec3">
<img width="3126" alt="Screenshot 2023-11-27 at 9 49 37 PM" src="https://github.com/twilio/twilio-webchat-react-app/assets/18657542/2fc44eb0-d739-4c58-a1f5-fff5cae58fa7">

Not sending `I-Twilio-UserAgent` anymore.
<img width="1698" alt="Screenshot 2023-12-06 at 12 57 21 PM" src="https://github.com/twilio/twilio-webchat-react-app/assets/18657542/f42aaeab-2497-41ad-8a3c-11be4b017dd0">


**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
